### PR TITLE
Add a parseString method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
 
 before_script:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Install via composer. Edit your project's composer.json file to require jflight/
     }
 
 Update Composer from the terminal:
-	
+
 	composer update
 #Usage
 Parse the cookies (currently supports [__utma__ and __utmz__](https://developers.google.com/analytics/devguides/collection/analyticsjs/cookie-usage)):
@@ -28,6 +28,18 @@ use Jflight\GACookie\GACookie;
 $utma = GACookie::parse('utma');
 $utmz = GACookie::parse('utmz');
 ```
+
+Or directly parse strings:
+
+```php
+<?php
+
+$utma = GACookie::parseString('utma', '177910838.254655113.1474876189.1482142331.1482148790.58');
+$utmz = GACookie::parseString('utmz', '177910838.1481550491.52.15.utmcsr=newsletter|utmccn=campaign-2016|utmcmd=email');
+
+```
+
+
 You can now access cookie variables:
 
 __For utma__

--- a/src/Jflight/GACookie/GACookie.php
+++ b/src/Jflight/GACookie/GACookie.php
@@ -18,4 +18,20 @@ class GACookie
 		$parser = $c->make('Jflight\GACookie\Parser');
 		return $parser->parse($cookieName);
 	}
+
+	/**
+	 * Static shortcut to Parser 'parse' method
+	 * @param  string $cookieName
+	 * @param  string $string
+	 * @return Jflight\GACookie\Cookie
+	 */
+	public static function parseString($cookieName, $string)
+	{
+		$c = new Container;
+		$c->bind('DateTime', function(){
+			return new \DateTime;
+		});
+		$parser = $c->make('Jflight\GACookie\Parser');
+		return $parser->parseString($cookieName, $string);
+	}
 }

--- a/src/Jflight/GACookie/Parser.php
+++ b/src/Jflight/GACookie/Parser.php
@@ -34,12 +34,37 @@ class Parser
 			{
 				return false;
 			}
-			
+
 		} else
 		{
 			throw new \InvalidArgumentException("'" . $cookieName . "' is not a supported google cookie type.");
 		}
-		
+
+	}
+
+	/**
+	 * Checks valid cookie type and passes the cookie string down to correct cookie object
+	 * @param  string $cookieName
+	 * @param  string $string
+	 * @return Jflight\GACookie\ParseInterface|bool
+	 */
+	public function parseString($cookieName, $string)
+	{
+		if (property_exists($this, $cookieName))
+		{
+			if ($string)
+			{
+				return $this->$cookieName->parse($string);
+			} else
+			{
+				return false;
+			}
+
+		} else
+		{
+			throw new \InvalidArgumentException("'" . $cookieName . "' is not a supported google cookie type.");
+		}
+
 	}
 
 	/**

--- a/tests/GACookie/ParserTest.php
+++ b/tests/GACookie/ParserTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Jflight\GACookie\Parser;
+use Jflight\GACookie\GACookie;
 use Mockery as m;
 
 class ParserTest extends PHPUnit_Framework_TestCase {
@@ -44,7 +45,23 @@ class ParserTest extends PHPUnit_Framework_TestCase {
 		$result = $parser->parse('utmz');
 		$this->assertSame(false,$result);
 	}
-	
+
+	public function testCanParseUtmaString()
+	{
+		$utma = GACookie::parseString('utma', '177910838.254655113.1474876189.1482142331.1482148790.58');
+		$this->assertEquals('2016-09-26 07:49:49', $utma->time_of_first_visit->format('Y-m-d H:i:s'));
+		$this->assertEquals('2016-12-19 10:12:11', $utma->time_of_last_visit->format('Y-m-d H:i:s'));
+		$this->assertEquals('2016-12-19 11:59:50', $utma->time_of_current_visit->format('Y-m-d H:i:s'));
+		$this->assertEquals(58, $utma->session_count);
+	}
+
+	public function testCanParseUtmzString()
+	{
+		$utmz = GACookie::parseString('utmz', '177910838.1481550491.52.15.utmcsr=newsletter|utmccn=campaign-2016|utmcmd=email');
+		$this->assertEquals('newsletter', $utmz->source);
+		$this->assertEquals('email', $utmz->medium);
+		$this->assertEquals('campaign-2016', $utmz->campaign);
+	}
 
 	protected function getParser()
 	{


### PR DESCRIPTION
Adds the ability to parse a custom string instead of the request cookie (as discussed in issue #2).